### PR TITLE
update messages added without refresh & chat extra prop send to child component & chat header commented

### DIFF
--- a/front-end/src/components/private/chat-header.tsx
+++ b/front-end/src/components/private/chat-header.tsx
@@ -12,7 +12,15 @@ import { toast } from "sonner";
 import api from "@/services/api";
 import type { ChatType } from "@/types/api-types";
 
-const ChatHeader = ({ chatId, chat }: { chatId: string; chat: ChatType }) => {
+const ChatHeader = ({
+  chatId,
+  chat,
+  updateMessages,
+}: {
+  chatId: string;
+  chat: ChatType;
+  updateMessages: (ids: []) => void;
+}) => {
   const typingUsers = chat.members;
   return (
     <div className="h-14 px-2 flex justify-between items-center border-b border-b-gray-200">
@@ -37,7 +45,7 @@ const ChatHeader = ({ chatId, chat }: { chatId: string; chat: ChatType }) => {
           </span>
         )}
       </div>
-      <MoreOptions chatId={chatId!} />
+      <MoreOptions chatId={chatId!} updateMessages={updateMessages} />
     </div>
   );
 };
@@ -52,7 +60,13 @@ type ResponseTypeDeleteMsg = {
   ok: boolean;
 };
 
-const MoreOptions = ({ chatId }: { chatId: string }) => {
+const MoreOptions = ({
+  chatId,
+  updateMessages,
+}: {
+  chatId: string;
+  updateMessages: (ids: []) => void;
+}) => {
   const router = useNavigate();
   const { removeOneChat } = useData();
   const handleDeleteChat = () => {
@@ -74,7 +88,7 @@ const MoreOptions = ({ chatId }: { chatId: string }) => {
           toast.error(res.data.message);
           return;
         }
-        location.reload();
+        updateMessages([]);
         toast.success(res.data.message);
       });
   };

--- a/front-end/src/components/private/chat-members.tsx
+++ b/front-end/src/components/private/chat-members.tsx
@@ -17,7 +17,7 @@ const ChatMembers = () => {
   }
   return (
     <div className="min-h-screen">
-      <ChatHeader chatId={chatId} chat={chat} />
+      {/* <ChatHeader chatId={chatId} chat={chat} /> */}
       <div className="flex justify-center items-center h-[80vh]">
         <div className="p-4 max-w-sm bg-white rounded-2xl shadow-md border border-gray-200">
           {/* Chat Name */}

--- a/front-end/src/components/private/chat-members.tsx
+++ b/front-end/src/components/private/chat-members.tsx
@@ -1,6 +1,6 @@
 import { useData } from "@/hooks/use-data";
 import { useParams } from "react-router";
-import ChatHeader from "./chat-header";
+// import ChatHeader from "./chat-header";
 
 const ChatMembers = () => {
   const { chatId } = useParams<{ chatId: string }>();

--- a/front-end/src/components/private/chat-messages.tsx
+++ b/front-end/src/components/private/chat-messages.tsx
@@ -86,7 +86,7 @@ const ChatMsgFunc = ({ chatId, chat }: { chatId: string; chat: ChatType }) => {
   return (
     <div className="h-[100vh]">
       {/* chat header */}
-      <ChatHeader chatId={chatId} chat={chat} />
+      <ChatHeader chatId={chatId} chat={chat} updateMessages={updateMessages} />
       {/* messages */}
       <div className="flex relative h-[calc(100vh-3.5rem)] flex-col">
         <AllMessages


### PR DESCRIPTION
### update messages added without refresh & chat extra prop send to child component & chat header commented
- [update messages added without refresh](https://github.com/kumar-rinku0/messaging/commit/dc6c7e63d0c0aece91667dfca8efd915b4ef8480)
- [chat header removed for now](https://github.com/kumar-rinku0/messaging/commit/15243f3591d2a954c8368145999de312fef0a73b)
- [chat extra prop send to child component](https://github.com/kumar-rinku0/messaging/commit/2e638387d7559ab516f28adcec684b5eeb52fae8)
- [chat header commented](https://github.com/kumar-rinku0/messaging/commit/100224b4d4ba207b6d3517b2315af1fbdb4a4b91)
- fixed #52 as completed already.